### PR TITLE
feat: write out results of tested seed phrase reconstruction to txt file

### DIFF
--- a/src/bip39.rs
+++ b/src/bip39.rs
@@ -236,6 +236,10 @@ impl Bip39Secret {
             .collect::<Vec<_>>()
             .join(" ")
     }
+    /// Generate the seed phrase (mnemonic) from the secret.
+    pub fn to_seed_phrase(&self, dictionary: &Bip39Dictionary) -> String {
+        self.to_mnemonic(dictionary)
+    }
 }
 
 #[cfg(test)]

--- a/src/bip39.rs
+++ b/src/bip39.rs
@@ -236,10 +236,6 @@ impl Bip39Secret {
             .collect::<Vec<_>>()
             .join(" ")
     }
-    /// Generate the seed phrase (mnemonic) from the secret.
-    pub fn to_seed_phrase(&self, dictionary: &Bip39Dictionary) -> String {
-        self.to_mnemonic(dictionary)
-    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,18 +6,16 @@ mod gf256;
 mod shamir;
 mod utils;
 
-use std::str::FromStr;
 use std::fs::File;
 use std::io::{self, Write};
+use std::str::FromStr;
 
 use clap::{command, Parser};
 use color_eyre::owo_colors::OwoColorize;
 use eyre::{ensure, Result};
 use prettytable::{
     format::{FormatBuilder, LinePosition, LineSeparator},
-    Cell,
-    Row,
-    Table,
+    Cell, Row, Table,
 };
 
 use crate::{
@@ -180,7 +178,12 @@ fn pretty_print_mnemonic(heading: &str, mnemonic: &str) {
 /// Double-check that the secret can be reconstructed from any `t` shares.
 /// Panic if the secret cannot be reconstructed.
 #[cfg(feature = "double-check")]
-fn double_check_shares(secret: &Bip39Secret, shares: &[Bip39Share], t: usize, dictionary: &Bip39Dictionary) -> io::Result<()> {
+fn double_check_shares(
+    secret: &Bip39Secret,
+    shares: &[Bip39Share],
+    t: usize,
+    dictionary: &Bip39Dictionary,
+) -> io::Result<()> {
     use itertools::Itertools;
 
     // Open a file for writing the output
@@ -190,7 +193,11 @@ fn double_check_shares(secret: &Bip39Secret, shares: &[Bip39Share], t: usize, di
 
     // Write the original seed phrase to the file
     let original_seed_phrase = secret.to_seed_phrase(dictionary);
-    writeln!(file, "Original seed phrase:\n\"{}\"\n", original_seed_phrase)?;
+    writeln!(
+        file,
+        "Original seed phrase:\n\"{}\"\n",
+        original_seed_phrase
+    )?;
 
     for share in shares {
         assert!(share.is_valid().is_ok(), "The share is invalid");
@@ -201,7 +208,11 @@ fn double_check_shares(secret: &Bip39Secret, shares: &[Bip39Share], t: usize, di
         let adjusted_combination: Vec<_> = combination.iter().map(|&i| i + 1).collect();
 
         // Print the combination index
-        println!("Testing combination {}: {:?}", index + 1, adjusted_combination);
+        println!(
+            "Testing combination {}: {:?}",
+            index + 1,
+            adjusted_combination
+        );
 
         let shares_subset = combination
             .into_iter()
@@ -216,11 +227,24 @@ fn double_check_shares(secret: &Bip39Secret, shares: &[Bip39Share], t: usize, di
 
         // Write the reconstructed seed phrase to the file
         let reconstructed_seed_phrase = reconstructed.to_seed_phrase(dictionary);
-        writeln!(file, "Reconstructed seed phrase from combination {}:", index + 1)?;
+        writeln!(
+            file,
+            "Reconstructed seed phrase from combination {}:",
+            index + 1
+        )?;
         for &i in &adjusted_combination {
-            writeln!(file, "  Share {}: \"{}\"", i, shares[i - 1].to_mnemonic(dictionary))?; // Adjust index back for accessing shares
+            writeln!(
+                file,
+                "  Share {}: \"{}\"",
+                i,
+                shares[i - 1].to_mnemonic(dictionary)
+            )?; // Adjust index back for accessing shares
         }
-        writeln!(file, "  Reconstructed seed phrase:\n    \"{}\"\n", reconstructed_seed_phrase)?;
+        writeln!(
+            file,
+            "  Reconstructed seed phrase:\n    \"{}\"\n",
+            reconstructed_seed_phrase
+        )?;
     }
 
     println!("\nWriting results to file: reconstructed_seed_phrases.txt\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,16 +6,20 @@ mod gf256;
 mod shamir;
 mod utils;
 
-use std::fs::File;
-use std::io::{self, Write};
-use std::str::FromStr;
+use std::{
+    fs::File,
+    io::{self, Write},
+    str::FromStr,
+};
 
 use clap::{command, Parser};
 use color_eyre::owo_colors::OwoColorize;
 use eyre::{ensure, Result};
 use prettytable::{
     format::{FormatBuilder, LinePosition, LineSeparator},
-    Cell, Row, Table,
+    Cell,
+    Row,
+    Table,
 };
 
 use crate::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ fn double_check_shares(
     println!("\nDouble-checking secret can be reconstructed from any {t} shares...\n");
 
     // Write the original seed phrase to the file
-    let original_seed_phrase = secret.to_seed_phrase(dictionary);
+    let original_seed_phrase = secret.to_mnemonic(dictionary);
     writeln!(
         file,
         "Original seed phrase:\n\"{}\"\n",
@@ -226,7 +226,7 @@ fn double_check_shares(
         );
 
         // Write the reconstructed seed phrase to the file
-        let reconstructed_seed_phrase = reconstructed.to_seed_phrase(dictionary);
+        let reconstructed_seed_phrase = reconstructed.to_mnemonic(dictionary);
         writeln!(
             file,
             "Reconstructed seed phrase from combination {}:",


### PR DESCRIPTION
While the `double_check_shares()` function does ensure that the original seed phrase can be reconstructed for any `t` shares, it doesn't display the results to the user (it only shows Ok/Fail). So if someone wants to validate this themselves, they will need to manually via the `cargo run reconstruct...` command. This can be fairly time-consuming and error prone depending on how many combinations there are. If someone wants to test a 2 of 4 reconstruction for all combinations, it will take quite a while. 

This change updates that function to output each n of m combination that is tested and then writes out the results to a file called `reconstructed_seed_phrases.txt`. For example, using the example from the `README`: `cargo run --features double-check split -t 2 -n 3 --secret "permit universe parent weapon amused modify essay borrow tobacco budget walnut lunch consider gallery ride amazing frog forget treat market chapter velvet useless topple"`, then the content of the `txt` file are automatically populated with the following: 

```
Original seed phrase:
"permit universe parent weapon amused modify essay borrow tobacco budget walnut lunch consider gallery ride amazing frog forget treat market chapter velvet useless topple"

Reconstructed seed phrase from combination 1:
  Share 1: "health attract purpose load weasel brother vague laundry utility zero olive word portion interest clock thrive stove present bar endless distance input quick pool"
  Share 2: "clown cloth royal artwork true pride drama stem shift supply gym exhibit candy apology odor head figure faint entry credit staff leg enroll skirt"
  Reconstructed seed phrase:
    "permit universe parent weapon amused modify essay borrow tobacco budget walnut lunch consider gallery ride amazing frog forget treat market chapter velvet useless topple"

Reconstructed seed phrase from combination 2:
  Share 1: "health attract purpose load weasel brother vague laundry utility zero olive word portion interest clock thrive stove present bar endless distance input quick pool"
  Share 3: "topic silver real jealous boring decide zero real stove desk agent daughter play camp arctic mind talk pass safe verb soccer wheat behind letter"
  Reconstructed seed phrase:
    "permit universe parent weapon amused modify essay borrow tobacco budget walnut lunch consider gallery ride amazing frog forget treat market chapter velvet useless topple"

Reconstructed seed phrase from combination 3:
  Share 2: "clown cloth royal artwork true pride drama stem shift supply gym exhibit candy apology odor head figure faint entry credit staff leg enroll skirt"
  Share 3: "topic silver real jealous boring decide zero real stove desk agent daughter play camp arctic mind talk pass safe verb soccer wheat behind letter"
  Reconstructed seed phrase:
    "permit universe parent weapon amused modify essay borrow tobacco budget walnut lunch consider gallery ride amazing frog forget treat market chapter velvet useless topple"
```